### PR TITLE
Fix dutch translation - Net Nu is not valid

### DIFF
--- a/android-ago/res/values-nl/strings.xml
+++ b/android-ago/res/values-nl/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-	<string name="just_now">Net nu</string>
+	<string name="just_now">Nu</string>
 </resources>


### PR DESCRIPTION
The previous translation for "Just Now" string was not a valid Dutch translation.
We got this bug in our app from the QA team, and the suggestion from the translators was to use just "Nu".